### PR TITLE
Example for ListDefinitionTests should contain CustomUrl

### DIFF
--- a/SPMeta2.Docs/Web/Definitions/Foundation/ListDefinitionTests.cs
+++ b/SPMeta2.Docs/Web/Definitions/Foundation/ListDefinitionTests.cs
@@ -15,7 +15,6 @@ namespace SPMeta2.Docs.ProvisionSamples.Provision.Definitions
     {
         #region methods
 
-
         [SampleMetadata(
             Title = "Adding list by template id",
             Description = "",
@@ -32,7 +31,7 @@ namespace SPMeta2.Docs.ProvisionSamples.Provision.Definitions
                 Title = "Generic list",
                 Description = "A generic list.",
                 TemplateType = BuiltInListTemplateTypeId.GenericList,
-                Url = "GenericList"
+                CustomUrl = "/Lists/GenericList"
             };
 
             var documentLibrary = new ListDefinition


### PR DESCRIPTION
I've added CustomUrl property to this example including the /Lists/ part so people can be aware of the fact that it has to be added for generic lists.
